### PR TITLE
feat: add login prompt

### DIFF
--- a/src/routes/auth/webex/redirect.ts
+++ b/src/routes/auth/webex/redirect.ts
@@ -7,13 +7,14 @@ export const GET = async (requestEvent: RequestEvent) => {
     return { status: 302, headers: { Location: '/demos' } };
   }
 
+  const prompt = 'select_account';
   const responseType = 'code';
   const redirectUri = requestEvent.url.origin + `/auth/webex/callback`;
   const state = requestEvent.locals.session?.uuid;
 
   const clientId = env.WEBEX_AUTHORIZATION_CODE_CLIENT_ID;
   const scope = env.WEBEX_AUTHORIZATION_CODE_CLIENT_SCOPE;
-  const params = humps.decamelizeKeys({ clientId, redirectUri, responseType, scope, state });
+  const params = humps.decamelizeKeys({ clientId, prompt, redirectUri, responseType, scope, state });
 
   return {
     status: 302,


### PR DESCRIPTION
If the browser already has an active Webex login session, the app will still prompt user to select the account to login with. This is to avoid any incorrect account logins.